### PR TITLE
MangaPlus extractor

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ test:
 executable:
 	scripts/pyinstaller.py
 
-completion: data/completion/gallery-dl data/completion/_gallery-dl
+completion: data/completion/gallery-dl data/completion/_gallery-dl data/completion/gallery-dl.fish
 
 man: data/man/gallery-dl.1 data/man/gallery-dl.conf.5
 
@@ -46,3 +46,6 @@ data/completion/gallery-dl: gallery_dl/option.py scripts/completion_bash.py
 
 data/completion/_gallery-dl: gallery_dl/option.py scripts/completion_zsh.py
 	$(PYTHON) scripts/completion_zsh.py
+
+data/completion/gallery-dl.fish: gallery_dl/option.py scripts/completion_fish.py
+	$(PYTHON) scripts/completion_fish.py

--- a/README.rst
+++ b/README.rst
@@ -124,11 +124,11 @@ Download images; in this case from danbooru via tag search for 'bonocho':
     $ gallery-dl "https://danbooru.donmai.us/posts?tags=bonocho"
 
 
-Get the direct URL of an image from a site that requires authentication:
+Get the direct URL of an image from a site supporting authentication with username & password:
 
 .. code:: bash
 
-    $ gallery-dl -g -u "<username>" -p "<password>" "https://seiga.nicovideo.jp/seiga/im3211703"
+    $ gallery-dl -g -u "<username>" -p "<password>" "https://twitter.com/i/web/status/604341487988576256"
 
 
 Filter manga chapters by language and chapter number:
@@ -199,7 +199,7 @@ Username & Password
 
 Some extractors require you to provide valid login credentials in the form of
 a username & password pair. This is necessary for
-``nijie`` and ``seiga``
+``nijie``
 and optional for
 ``aryion``,
 ``danbooru``,
@@ -225,7 +225,7 @@ You can set the necessary information in your configuration file
 
     {
         "extractor": {
-            "seiga": {
+            "twitter": {
                 "username": "<username>",
                 "password": "<password>"
             }

--- a/README.rst
+++ b/README.rst
@@ -38,14 +38,14 @@ easily installed or upgraded using pip_:
 
 .. code:: bash
 
-    $ python3 -m pip install -U gallery-dl
+    python3 -m pip install -U gallery-dl
 
 Installing the latest dev version directly from GitHub can be done with
 pip_ as well:
 
 .. code:: bash
 
-    $ python3 -m pip install -U -I --no-deps --no-cache-dir https://github.com/mikf/gallery-dl/archive/master.tar.gz
+    python3 -m pip install -U -I --no-deps --no-cache-dir https://github.com/mikf/gallery-dl/archive/master.tar.gz
 
 Note: Windows users should use :code:`py -3` instead of :code:`python3`.
 
@@ -55,7 +55,7 @@ To ensure these packages are up-to-date, run
 
 .. code:: bash
 
-    $ python3 -m pip install --upgrade pip setuptools wheel
+    python3 -m pip install --upgrade pip setuptools wheel
 
 
 Standalone Executable
@@ -78,7 +78,7 @@ Linux users that are using a distro that is supported by Snapd_ can install *gal
 
 .. code:: bash
 
-    $ snap install gallery-dl
+    snap install gallery-dl
 
 
 Chocolatey
@@ -88,7 +88,7 @@ Windows users that have Chocolatey_ installed can install *gallery-dl* from the 
 
 .. code:: powershell
 
-    $ choco install gallery-dl
+    choco install gallery-dl
 
 
 Scoop
@@ -98,7 +98,7 @@ Scoop
 
 .. code:: powershell
 
-    $ scoop install gallery-dl
+    scoop install gallery-dl
 
 
 Usage
@@ -109,7 +109,7 @@ from:
 
 .. code:: bash
 
-    $ gallery-dl [OPTION]... URL...
+    gallery-dl [OPTION]... URL...
 
 See also :code:`gallery-dl --help`.
 
@@ -121,21 +121,21 @@ Download images; in this case from danbooru via tag search for 'bonocho':
 
 .. code:: bash
 
-    $ gallery-dl "https://danbooru.donmai.us/posts?tags=bonocho"
+    gallery-dl "https://danbooru.donmai.us/posts?tags=bonocho"
 
 
 Get the direct URL of an image from a site supporting authentication with username & password:
 
 .. code:: bash
 
-    $ gallery-dl -g -u "<username>" -p "<password>" "https://twitter.com/i/web/status/604341487988576256"
+    gallery-dl -g -u "<username>" -p "<password>" "https://twitter.com/i/web/status/604341487988576256"
 
 
 Filter manga chapters by language and chapter number:
 
 .. code:: bash
 
-    $ gallery-dl --chapter-filter "lang == 'fr' and 10 <= chapter < 20" "https://mangadex.org/title/2354/"
+    gallery-dl --chapter-filter "lang == 'fr' and 10 <= chapter < 20" "https://mangadex.org/title/2354/"
 
 
 | Search a remote resource for URLs and download images from them:
@@ -143,7 +143,7 @@ Filter manga chapters by language and chapter number:
 
 .. code:: bash
 
-    $ gallery-dl "r:https://pastebin.com/raw/FLwrCYsT"
+    gallery-dl "r:https://pastebin.com/raw/FLwrCYsT"
 
 
 If a site's address is nonstandard for its extractor, you can prefix the URL with the
@@ -151,7 +151,7 @@ extractor's name to force the use of a specific extractor:
 
 .. code:: bash
 
-    $ gallery-dl "tumblr:https://sometumblrblog.example"
+    gallery-dl "tumblr:https://sometumblrblog.example"
 
 
 Configuration
@@ -238,8 +238,8 @@ or you can provide them directly via the
 
 .. code:: bash
 
-    $ gallery-dl -u <username> -p <password> URL
-    $ gallery-dl -o username=<username> -o password=<password> URL
+    gallery-dl -u <username> -p <password> URL
+    gallery-dl -o username=<username> -o password=<password> URL
 
 
 Cookies
@@ -283,7 +283,7 @@ the :code:`--cookies` command-line option:
 
 .. code:: bash
 
-    $ gallery-dl --cookies "$HOME/path/to/cookies.txt" URL
+    gallery-dl --cookies "$HOME/path/to/cookies.txt" URL
 
 
 OAuth
@@ -301,7 +301,7 @@ To link your account to *gallery-dl*, start by invoking it with
 
 .. code:: bash
 
-    $ gallery-dl oauth:flickr
+    gallery-dl oauth:flickr
 
 You will be sent to the site's authorization page and asked to grant read
 access to *gallery-dl*. Authorize it and you will be shown one or more
@@ -312,8 +312,8 @@ To authenticate with a ``mastodon`` instance, run *gallery-dl* with
 
 .. code:: bash
 
-    $ gallery-dl oauth:mastodon:pawoo.net
-    $ gallery-dl oauth:mastodon:https://mastodon.social/
+    gallery-dl oauth:mastodon:pawoo.net
+    gallery-dl oauth:mastodon:https://mastodon.social/
 
 
 

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -477,6 +477,7 @@ Description
     | Can be either a simple ``string`` with just the local IP address
     | or a ``list`` with IP and explicit port number as elements.
 
+
 extractor.*.user-agent
 ----------------------
 Type
@@ -2617,6 +2618,17 @@ Default
     `extractor.*.verify`_
 Description
     Certificate validation during file downloads.
+
+
+downloader.*.proxy
+------------------
+Type
+    ``string`` or ``object``
+Default
+    `extractor.*.proxy`_
+Description
+    | Proxy server used for file downloads.
+    | Disable the use of a proxy by explicitly setting this option to ``null``.
 
 
 downloader.http.adjust-extensions

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -356,7 +356,6 @@ Description
     Specifying a username and password is required for
 
     * ``nijie``
-    * ``seiga``
 
     and optional for
 

--- a/docs/supportedsites.md
+++ b/docs/supportedsites.md
@@ -521,7 +521,7 @@ Consider all sites to be NSFW unless otherwise known.
     <td>Niconico Seiga</td>
     <td>https://seiga.nicovideo.jp/</td>
     <td>individual Images, User Profiles</td>
-    <td>Required</td>
+    <td><a href="https://github.com/mikf/gallery-dl#cookies">Cookies</a></td>
 </tr>
 <tr>
     <td>nijie</td>

--- a/gallery_dl/downloader/common.py
+++ b/gallery_dl/downloader/common.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright 2014-2020 Mike Fährmann
+# Copyright 2014-2022 Mike Fährmann
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 2 as
@@ -26,6 +26,12 @@ class DownloaderBase():
         if self.partdir:
             self.partdir = util.expand_path(self.partdir)
             os.makedirs(self.partdir, exist_ok=True)
+
+        proxies = self.config("proxy", util.SENTINEL)
+        if proxies is util.SENTINEL:
+            self.proxies = job.extractor._proxies
+        else:
+            self.proxies = util.build_proxy_map(proxies, self.log)
 
     def config(self, key, default=None):
         """Interpolate downloader config value for 'key'"""

--- a/gallery_dl/downloader/http.py
+++ b/gallery_dl/downloader/http.py
@@ -121,7 +121,8 @@ class HttpDownloader(DownloaderBase):
             try:
                 response = self.session.request(
                     "GET", url, stream=True, headers=headers,
-                    timeout=self.timeout, verify=self.verify)
+                    timeout=self.timeout, verify=self.verify,
+                    proxies=self.proxies)
             except (ConnectionError, Timeout) as exc:
                 msg = str(exc)
                 continue

--- a/gallery_dl/downloader/ytdl.py
+++ b/gallery_dl/downloader/ytdl.py
@@ -25,6 +25,7 @@ class YoutubeDLDownloader(DownloaderBase):
             "retries": retries+1 if retries >= 0 else float("inf"),
             "socket_timeout": self.config("timeout", extractor._timeout),
             "nocheckcertificate": not self.config("verify", extractor._verify),
+            "proxy": self.proxies.get("http") if self.proxies else None,
         }
 
         self.ytdl_instance = None

--- a/gallery_dl/extractor/common.py
+++ b/gallery_dl/extractor/common.py
@@ -55,6 +55,7 @@ class Extractor():
         self._retries = self.config("retries", 4)
         self._timeout = self.config("timeout", 30)
         self._verify = self.config("verify", True)
+        self._proxies = util.build_proxy_map(self.config("proxy"), self.log)
         self._interval = util.build_duration_func(
             self.config("sleep-request", self.request_interval),
             self.request_interval_min,
@@ -65,7 +66,6 @@ class Extractor():
 
         self._init_session()
         self._init_cookies()
-        self._init_proxies()
 
     @classmethod
     def from_url(cls, url):
@@ -104,10 +104,12 @@ class Extractor():
 
     def request(self, url, *, method="GET", session=None, retries=None,
                 encoding=None, fatal=True, notfound=None, **kwargs):
-        if retries is None:
-            retries = self._retries
         if session is None:
             session = self.session
+        if retries is None:
+            retries = self._retries
+        if "proxies" not in kwargs:
+            kwargs["proxies"] = self._proxies
         if "timeout" not in kwargs:
             kwargs["timeout"] = self._timeout
         if "verify" not in kwargs:
@@ -288,20 +290,6 @@ class Extractor():
             ssl_options, ssl_ciphers, source_address)
         session.mount("https://", adapter)
         session.mount("http://", adapter)
-
-    def _init_proxies(self):
-        """Update the session's proxy map"""
-        proxies = self.config("proxy")
-        if proxies:
-            if isinstance(proxies, str):
-                proxies = {"http": proxies, "https": proxies}
-            if isinstance(proxies, dict):
-                for scheme, proxy in proxies.items():
-                    if "://" not in proxy:
-                        proxies[scheme] = "http://" + proxy.lstrip("/")
-                self.session.proxies = proxies
-            else:
-                self.log.warning("invalid proxy specifier: %s", proxies)
 
     def _init_cookies(self):
         """Populate the session's cookiejar"""

--- a/gallery_dl/extractor/fanbox.py
+++ b/gallery_dl/extractor/fanbox.py
@@ -51,19 +51,16 @@ class FanboxExtractor(Extractor):
             url = text.ensure_http_scheme(url)
             body = self.request(url, headers=headers).json()["body"]
             for item in body["items"]:
-                yield self._process_post(item)
+                yield self._get_post_data(item["id"])
 
             url = body["nextUrl"]
 
-    def _get_post_data_from_id(self, post_id):
+    def _get_post_data(self, post_id):
         """Fetch and process post data"""
         headers = {"Origin": self.root}
         url = "https://api.fanbox.cc/post.info?postId="+post_id
         post = self.request(url, headers=headers).json()["body"]
 
-        return self._process_post(post)
-
-    def _process_post(self, post):
         content_body = post.pop("body", None)
         if content_body:
             if "html" in content_body:
@@ -279,7 +276,7 @@ class FanboxPostExtractor(FanboxExtractor):
         self.post_id = match.group(3)
 
     def posts(self):
-        return (self._get_post_data_from_id(self.post_id),)
+        return (self._get_post_data(self.post_id),)
 
 
 class FanboxRedirectExtractor(Extractor):

--- a/gallery_dl/extractor/skeb.py
+++ b/gallery_dl/extractor/skeb.py
@@ -140,7 +140,7 @@ class SkebPostExtractor(SkebExtractor):
         self.post_num = match.group(2)
 
     def posts(self):
-        return (self.user_name, self.post_num,)
+        return ((self.user_name, self.post_num),)
 
 
 class SkebUserExtractor(SkebExtractor):

--- a/gallery_dl/extractor/subscribestar.py
+++ b/gallery_dl/extractor/subscribestar.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright 2020-2021 Mike Fährmann
+# Copyright 2020-2022 Mike Fährmann
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 2 as
@@ -105,7 +105,7 @@ class SubscribestarExtractor(Extractor):
                         att, 'data-upload-id="', '"')[0]),
                     "name": text.unescape(text.extract(
                         att, 'doc_preview-title">', '<')[0] or ""),
-                    "url" : text.extract(att, 'href="', '"')[0],
+                    "url" : text.unescape(text.extract(att, 'href="', '"')[0]),
                     "type": "attachment",
                 })
 

--- a/gallery_dl/extractor/ytdl.py
+++ b/gallery_dl/extractor/ytdl.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright 2021 Mike Fährmann
+# Copyright 2021-2022 Mike Fährmann
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 2 as
@@ -63,6 +63,9 @@ class YoutubeDLExtractor(Extractor):
             "socket_timeout"         : self._timeout,
             "nocheckcertificate"     : not self._verify,
         }
+
+        if self._proxies:
+            user_opts["proxy"] = self._proxies.get("http")
 
         username, password = self._get_auth_info()
         if username:

--- a/gallery_dl/util.py
+++ b/gallery_dl/util.py
@@ -522,6 +522,26 @@ def build_extractor_filter(categories, negate=True, special=None):
         return lambda extr: any(t(extr) for t in tests)
 
 
+def build_proxy_map(proxies, log=None):
+    """Generate a proxy map"""
+    if not proxies:
+        return None
+
+    if isinstance(proxies, str):
+        if "://" not in proxies:
+            proxies = "http://" + proxies.lstrip("/")
+        return {"http": proxies, "https": proxies}
+
+    if isinstance(proxies, dict):
+        for scheme, proxy in proxies.items():
+            if "://" not in proxy:
+                proxies[scheme] = "http://" + proxy.lstrip("/")
+        return proxies
+
+    if log:
+        log.warning("invalid proxy specifier: %s", proxies)
+
+
 def build_predicate(predicates):
     if not predicates:
         return lambda url, kwdict: True

--- a/gallery_dl/ytdl.py
+++ b/gallery_dl/ytdl.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright 2021 Mike Fährmann
+# Copyright 2021-2022 Mike Fährmann
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 2 as
@@ -46,8 +46,6 @@ def construct_YoutubeDL(module, obj, user_opts, system_opts=None):
 
     if opts.get("format") is None:
         opts["format"] = config("format")
-    if opts.get("proxy") is None:
-        opts["proxy"] = obj.session.proxies.get("http")
     if opts.get("nopart") is None:
         opts["nopart"] = not config("part", True)
     if opts.get("updatetime") is None:

--- a/scripts/completion_fish.py
+++ b/scripts/completion_fish.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 2 as
+# published by the Free Software Foundation.
+
+"""Generate fish completion script from gallery-dl's argument parser"""
+
+import util
+from gallery_dl import option
+
+
+TEMPLATE = """complete -c gallery-dl -x
+%(opts)s
+"""
+
+opts = []
+for action in option.build_parser()._actions:
+    if not action.option_strings:
+        continue
+
+    opt = "complete -c gallery-dl"
+
+    if action.metavar:
+        if action.metavar == "FILE":
+            opt += " -r -F"
+        elif action.metavar == "PATH":
+            opt += " -x -a '(__fish_complete_directories)'"
+        else:
+            opt += " -x"
+
+    for optstr in action.option_strings:
+        if optstr.startswith("--"):
+            opt += " -l '" + optstr[2:] + "'"
+        else:
+            opt += " -s '" + optstr[1:] + "'"
+
+    opt += " -d '" + action.help.replace("'", '"') + "'"
+
+    opts.append(opt)
+
+PATH = util.path("data/completion/gallery-dl.fish")
+with open(PATH, "w", encoding="utf-8") as file:
+    file.write(TEMPLATE % {"opts": "\n".join(opts)})

--- a/scripts/supportedsites.py
+++ b/scripts/supportedsites.py
@@ -265,7 +265,7 @@ AUTH_MAP = {
     "ponybooru"      : "API Key",
     "reddit"         : _OAUTH,
     "sankaku"        : "Supported",
-    "seiga"          : "Required",
+    "seiga"          : _COOKIES,
     "seisoparty"     : "Supported",
     "smugmug"        : _OAUTH,
     "subscribestar"  : "Supported",

--- a/setup.py
+++ b/setup.py
@@ -35,6 +35,7 @@ FILES = [
     for (path, files) in [
         ("share/bash-completion/completions", ["data/completion/gallery-dl"]),
         ("share/zsh/site-functions"         , ["data/completion/_gallery-dl"]),
+        ("share/fish/vendor_completions.d"  , ["data/completion/gallery-dl.fish"]),
         ("share/man/man1"                   , ["data/man/gallery-dl.1"]),
         ("share/man/man5"                   , ["data/man/gallery-dl.conf.5"]),
     ]

--- a/test/test_cookies.py
+++ b/test/test_cookies.py
@@ -89,7 +89,7 @@ class TestCookiedict(unittest.TestCase):
         self.assertEqual(sorted(cookies.values()), sorted(self.cdict.values()))
 
     def test_domain(self):
-        for category in ["exhentai", "idolcomplex", "nijie", "seiga"]:
+        for category in ["exhentai", "idolcomplex", "nijie"]:
             extr = _get_extractor(category)
             cookies = extr.session.cookies
             for key in self.cdict:
@@ -108,7 +108,6 @@ class TestCookieLogin(unittest.TestCase):
             "exhentai"   : ("ipb_member_id", "ipb_pass_hash"),
             "idolcomplex": ("login", "pass_hash"),
             "nijie"      : ("nemail", "nlogin"),
-            "seiga"      : ("user_session",),
         }
         for category, cookienames in extr_cookies.items():
             cookies = {name: "value" for name in cookienames}


### PR DESCRIPTION
Closes #412

This PR adds

- A MangaPlus extractor for chapters and manga
- A postprocessor (`mangaplus_unscramble`) to undo DRM on downloads from MangaPlus
- A prototype buffer parser in the makefile

A few issues still remain before this is ready for merge,
- [ ] ´--chapter-filter´ seems to not work for some reason (try `gallery-dl https://mangaplus.shueisha.co.jp/titles/100187 --chapter-filter="chapter == 2"`
- [ ] Running `mangaplus_unscramble` before `zip` seems to not include files from the first preprocessor. (Possible I'm doing something wrong here, so please advice! :pray:)
- [ ] We should add documentation that `protoc` is now needed to build gallery_dl

One more nice to have; is it possible to automatically run `mangaplus_unscramble` for this extractor? The files output are unreadable without this, it would make sense to have this work out of the box.